### PR TITLE
default setting for the new SITECONFIG_PATH environmental variable

### DIFF
--- a/cmsset_default.csh
+++ b/cmsset_default.csh
@@ -35,6 +35,11 @@ if ( ! ${?CMS_PATH} ) then
     setenv CMS_PATH $here
 endif
 
+# decouple SITECONF location form CMS_PATH to allow sub-sites:
+if ( ! ${?SITECONFIG_PATH} ) then
+    setenv SITECONFIG_PATH ${CMS_PATH}/SITECONF/local
+endif
+
 # aliases
 alias cmsenv 'eval `scramv1 runtime -csh`'
 alias cmsrel 'scramv1 project CMSSW'

--- a/cmsset_default.sh
+++ b/cmsset_default.sh
@@ -37,6 +37,12 @@ then
     export CMS_PATH=$here
 fi
 
+# decouple SITECONF location form CMS_PATH to allow sub-sites:
+if [ ! $SITECONFIG_PATH ]
+then
+    export SITECONFIG_PATH=${CMS_PATH}/SITECONF/local
+fi
+
 # aliases
 alias cmsenv='eval `scramv1 runtime -sh`'
 alias cmsrel='scramv1 project CMSSW'


### PR DESCRIPTION
Hallo Shahzad, et al.
   the pull request is to modify cmsset_default.[c]sh
adding a default setting for the new SITECONFIG_PATH
environmental variable. We want to/need to decouple
the SITECONF location from CMSSW location to allow
a proper sub-site mechanism and to enable institutes
to provide more than one site/sub-site on a worker
node, i.e. different than the current "local" link.
   We had a discussion on how to best implement
this quite a while back but couldn't start on it. Matti
and Chris were involved in the discussions.
   Thanks,
- Stephan