### PR TITLE
SITECONFIG_PATH needs now to be used for cmsset_local.[c]sh

### DIFF
--- a/cmsset_default.csh
+++ b/cmsset_default.csh
@@ -44,8 +44,8 @@ endif
 alias cmsenv 'eval `scramv1 runtime -csh`'
 alias cmsrel 'scramv1 project CMSSW'
 
-if( -e $CMS_PATH/SITECONF/local/JobConfig/cmsset_local.csh ) then
-        source $CMS_PATH/SITECONF/local/JobConfig/cmsset_local.csh
+if( -e $SITECONFIG_PATH/JobConfig/cmsset_local.csh ) then
+        source $SITECONFIG_PATH/JobConfig/cmsset_local.csh
 endif
 
 if ( ! ${?CVSROOT}) then

--- a/cmsset_default.sh
+++ b/cmsset_default.sh
@@ -47,8 +47,8 @@ fi
 alias cmsenv='eval `scramv1 runtime -sh`'
 alias cmsrel='scramv1 project CMSSW'
 
-if [ -f $CMS_PATH/SITECONF/local/JobConfig/cmsset_local.sh ]; then
-        . $CMS_PATH/SITECONF/local/JobConfig/cmsset_local.sh
+if [ -f $SITECONFIG_PATH/JobConfig/cmsset_local.sh ]; then
+        . $SITECONFIG_PATH/JobConfig/cmsset_local.sh
 fi
 
 if [ ! $CVSROOT ]


### PR DESCRIPTION
Hallo Shahzad,
   i just realized that cmsset_local.[c]sh now needs to be picked up via
SITECONFIG_PATH and not CMS_PATH, otherwise the environment
might be inconsistent.
   Thanks,
- Stephan