### PR TITLE
Update scr4am runtime hook for XrdSecPROTOCOL

### DIFF
--- a/etc/scramrc/SCRAM/hooks/runtime/10-xrootd-XrdSecPROTOCOL.sh
+++ b/etc/scramrc/SCRAM/hooks/runtime/10-xrootd-XrdSecPROTOCOL.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 [ -z "${XrdSecPROTOCOL}" ] || exit 0
-[ ! -z "${JOB_GLIDEIN_Factory}" ] || exit 0
+[ ! -z "${GLIDEIN_Factory}" ] || exit 0
 [ ! -z "${SCRAM}" ] || SCRAM="scram"
 ver=$(${SCRAM} tool info xrootd 2>&1 | grep '^Version *: ' | sed 's|^Version *: *||;s| *$||' | cut -d. -f1,2)
 if [[ "${ver}" =~ ^(4.[6-9]|5.0)$ ]] ; then


### PR DESCRIPTION
Use `GLIDEIN_Factory`  instead of `JOB_GLIDEIN_Factory` (see  https://ggus.eu/index.php?mode=ticket_info&ticket_id=162582 )