### PR TITLE
Added site based project hook

### DIFF
--- a/etc/scramrc/SCRAM/hooks/hooks.sh
+++ b/etc/scramrc/SCRAM/hooks/hooks.sh
@@ -3,7 +3,7 @@ SCRIPT_DIR=$(dirname $0)
 HOOK_TYPE=$(basename $0 | sed -e 's|-hook$||')
 export LC_ALL=C
 if [ -e ${SCRIPT_DIR}/${HOOK_TYPE} ] ; then
-  for hook in $(find ${SCRIPT_DIR}/${HOOK_TYPE} -type f | sort) ; do
+  for hook in $(find ${SCRIPT_DIR}/${HOOK_TYPE} -type f -o -type l | sort) ; do
     hook_name=$(echo $hook | sed "s|${SCRIPT_DIR}/||")
     if [ "${SCRAM_IGNORE_HOOKS}" != "" -a -e "${SCRAM_IGNORE_HOOKS}" ] ;  then
       grep -q "^${hook_name}$" "${SCRAM_IGNORE_HOOKS}" && continue

--- a/etc/scramrc/SCRAM/hooks/project-hook
+++ b/etc/scramrc/SCRAM/hooks/project-hook
@@ -1,0 +1,1 @@
+hooks.sh

--- a/etc/scramrc/SCRAM/hooks/project/00-os-mismatch
+++ b/etc/scramrc/SCRAM/hooks/project/00-os-mismatch
@@ -1,0 +1,23 @@
+#!/bin/bash
+sys_cmsos=$(BUILD_ARCH="" cmsos)
+sys_arch=$(echo ${sys_cmsos}    | cut -d_ -f2)
+scram_arch=$(echo ${SCRAM_ARCH} | cut -d_ -f2 | sed -e 's/^\(cc\|cs\)/el/')
+
+if [ "${sys_arch}" != "${scram_arch}" ] ; then
+  echo "ERROR: You are trying to use SCRAM architecture '${scram_arch}' on '${sys_arch}' host. This will not build/run.
+       Please either set/use correct SCRAM_ARCH or move to a suitable '${scram_arch}' host."
+  exit 1
+fi
+
+sys_os=$(echo ${sys_cmsos}    | cut -d_ -f1)
+scram_os=$(echo ${SCRAM_ARCH} | cut -d_ -f1)
+scram_os1=$(echo ${scram_os} | sed -e 's/^\(cc\|cs\)/el/')
+
+if [ "${sys_os}" != "${scram_os1}" ] ; then
+  scram_os1=$(echo ${scram_os} | sed -e 's/^\(cc\|cs\|slc\)/el/')
+  echo "WARNING: You are trying to use SCRAM architecture '${scram_os}' on host with operating system '${sys_os}'.
+         This might not work and you might get build/runtime errors. Please either
+         - use correct SCRAM_ARCH to match your host's operating system.
+         - OR use 'cmssw-${scram_os1}' script to start a singularity container (http://cms-sw.github.io/singularity.html)
+         - OR use host which has '${scram_os}' installed e.g. lxplus8 for el8, lxplus9 for el9 or lxplus7 for slc7."
+fi

--- a/etc/scramrc/SCRAM/hooks/project/00-os-mismatch
+++ b/etc/scramrc/SCRAM/hooks/project/00-os-mismatch
@@ -16,7 +16,7 @@ scram_os1=$(echo ${scram_os} | sed -e 's/^\(cc\|cs\)/el/')
 if [ "${sys_os}" != "${scram_os1}" ] ; then
   scram_os1=$(echo ${scram_os} | sed -e 's/^\(cc\|cs\|slc\)/el/')
   echo "WARNING: You are trying to use SCRAM architecture '${scram_os}' on host with operating system '${sys_os}'.
-         This might not work and you might get build/runtime errors. Please either
+         This is not supported and likely will not work and you might get build/runtime errors. Please either
          - use correct SCRAM_ARCH to match your host's operating system.
          - OR use 'cmssw-${scram_os1}' script to start a singularity container (http://cms-sw.github.io/singularity.html)
          - OR use host which has '${scram_os}' installed e.g. lxplus8 for el8, lxplus9 for el9 or lxplus7 for slc7."

--- a/etc/scramrc/SCRAM/hooks/runtime/00-os-mismatch
+++ b/etc/scramrc/SCRAM/hooks/runtime/00-os-mismatch
@@ -1,0 +1,1 @@
+../project/00-os-mismatch


### PR DESCRIPTION
This adds new site based scram project/runtime hook to check the mismatch between scram arch/os and host arch/os. New hook will print a warnings about scram/host arch/os mismatch. Note that this does not change the `scram project` or `scram runtime|cmsenv` behavior. 

[a] scram project
```
> scram -a slc7_amd64_gcc12 p CMSSW_14_1_0_pre2
WARNING: Developer's area is created for architecture slc7_amd64_gcc12 while your current OS is el8_amd64.
WARNING: Developer's area is created for non-production architecture slc7_amd64_gcc12. Production architecture for this release is el8_amd64_gcc12
WARNING: You are trying to use SCRAM architecture 'slc7' on host with operating system 'el8'.
         This is not supported and likely will not work and you might get build/runtime errors. Please either
         - use correct SCRAM_ARCH to match your host's operating system.
         - OR use 'cmssw-el7' script to start a singularity container (http://cms-sw.github.io/singularity.html)
         - OR use host which has 'slc7' installed e.g. lxplus8 for el8, lxplus9 for el9 or lxplus7 for slc7.
> echo $?
0
```
[b] scram runtime | cmsenv
```
> cmsenv
WARNING: You are trying to use SCRAM architecture 'slc7' on host with operating system 'el8'.
         This is not supported and likely will not work and you might get build/runtime errors. Please either
         - use correct SCRAM_ARCH to match your host's operating system.
         - OR use 'cmssw-el7' script to start a singularity container (http://cms-sw.github.io/singularity.html)
         - OR use host which has 'slc7' installed e.g. lxplus8 for el8, lxplus9 for el9 or lxplus7 for slc7.
> echo $?
0
```
