### PR TITLE
avoid interference from GREP_OPTIONS in older OSes

### DIFF
--- a/cmsset_default.sh
+++ b/cmsset_default.sh
@@ -24,7 +24,7 @@ fi
 for arch in share ${SCRAM_ARCH} ; do
   if [ -d $here/${arch}/etc/profile.d ]
   then
-    for pkg in $(/bin/ls $here/${arch}/etc/profile.d/ | grep 'S.*[.]sh')
+    for pkg in $(/bin/ls $here/${arch}/etc/profile.d/ | env -u GREP_OPTIONS grep 'S.*[.]sh')
     do
           source $here/${arch}/etc/profile.d/$pkg
     done


### PR DESCRIPTION
A user showed me an interesting failure mode for our CMS container/environment commands recently. It took me a while to isolate the cause, but here's the reproducer:
```bash
cat << EOF > .fakerc
export GREP_OPTIONS='--color=always' GREP_COLOR='1;32'
source /cvmfs/cms.cern.ch/cmsset_default.sh
EOF
cmssw-el7 -- /bin/bash --rcfile .fakerc
```
The output is shown as a screenshot to illustrate the problem:
![image](https://github.com/user-attachments/assets/4618343d-7ebd-41d0-a7b2-591b4e9de521)

The supposedly missing filenames are shown as green because the text actually contains the extra color-setting characters, introduced by the `GREP_OPTIONS` environment variable. el8 will warn about this variable (but still have the failure), while el9 does not have this problem (because it has a newer grep version).

The simple fix in this PR will prevent this from happening on the older OSes that we still support via Apptainer.