### PR TITLE
Force LC_ALL=C for el9 archs 

### DIFF
--- a/etc/scramrc/SCRAM/hooks/runtime/00-lc_all-env
+++ b/etc/scramrc/SCRAM/hooks/runtime/00-lc_all-env
@@ -1,5 +1,5 @@
 #!/bin/bash
 case $SCRAM_ARCH in
-  slc6_*|slc7_*) echo "RUNTIME:variable:LC_ALL=C" ;;
+  slc6_*|slc7_*|el8_*|el9_*) echo "RUNTIME:variable:LC_ALL=C" ;;
   * ) ;;
 esac

--- a/etc/scramrc/SCRAM/hooks/runtime/00-lc_all-env
+++ b/etc/scramrc/SCRAM/hooks/runtime/00-lc_all-env
@@ -1,5 +1,2 @@
 #!/bin/bash
-case $SCRAM_ARCH in
-  slc6_*|slc7_*|el8_*|el9_*) echo "RUNTIME:variable:LC_ALL=C" ;;
-  * ) ;;
-esac
+echo "RUNTIME:variable:LC_ALL=C"


### PR DESCRIPTION
In Combine we recently noticed that RooFit depends on LC_NUMERIC settings, see an issue in the repo https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/issues/1048 
It would be good if these variables are unset centrally for CMSSW setup. I guess the changes proposed here should suffice  or should I add `export LC_ALL=C` to [this](https://github.com/cms-sw/cms-common/blob/master/cmsset_default.sh) file? 