### PR TITLE
Print stack trace and exit with non-zero code if the traced application crashes

### DIFF
--- a/common/cmsTraceFunction
+++ b/common/cmsTraceFunction
@@ -19,6 +19,15 @@ script = [
     "set pagination off",
     "set breakpoint pending on",
 ]
+# Same signals as in InitRootHandlers
+for signal in ["SIGILL", "SIGSEGV", "SIGBUS", "SIGTERM", "SIGFPE", "SIGABRT"]:
+    script.extend([
+        "catch signal "+signal,
+        "command",
+        "thread apply all bt",
+        "quit 1",
+        "end",
+    ])
 
 runIssued = False
 if args.startAfterFunction:


### PR DESCRIPTION
Resolves https://github.com/cms-sw/cmssw/issues/48939

Resolves https://github.com/cms-sw/framework-team/issues/1578

Tested privately with https://github.com/cms-sw/cmssw/pull/49005