### PR TITLE
use exact path to python executable for pyvenv.cfg home

### DIFF
--- a/common/scram-venv
+++ b/common/scram-venv
@@ -14,7 +14,7 @@ fi
 
 # get info from existing python
 PYPATH=$(which python3)
-PYHOME=$(dirname $PYPATH)
+PYHOME=$(dirname $(readlink -f $PYPATH))
 PYVERSION=$(python3 --version | cut -d' ' -f2)
 PYVERSHORT=$(echo $PYVERSION | cut -d'.' -f1-2)
 PYVERSHORTER=$(echo $PYVERSION | cut -d'.' -f1)


### PR DESCRIPTION
`scram-venv` broke for Python 3.12 because Python is more strict about paths starting from Python 3.11. Using `readlink -f` in the right place fixes it and is backward-compatible for Python 3.9.